### PR TITLE
Misc improvements

### DIFF
--- a/src/TreeHouse/BehatCommon/AbstractPersistenceContext.php
+++ b/src/TreeHouse/BehatCommon/AbstractPersistenceContext.php
@@ -181,6 +181,11 @@ abstract class AbstractPersistenceContext extends RawMinkContext
     }
 
     /**
+     * Purges the relevant database.
+     */
+    abstract protected function purgeDatabase();
+
+    /**
      * @param string $name
      * @param array  $data
      *
@@ -203,10 +208,4 @@ abstract class AbstractPersistenceContext extends RawMinkContext
      * @throw \PHPUnit_Framework_ExpectationFailedException
      */
     abstract protected function assertDataNotPersisted($name, array $data);
-
-    /**
-     * Purges the relevant database, if the scenario was tagged
-     * with the tag configured during construction.
-     */
-    abstract protected function purgeDatabase();
 }

--- a/src/TreeHouse/BehatCommon/AbstractPersistenceContext.php
+++ b/src/TreeHouse/BehatCommon/AbstractPersistenceContext.php
@@ -2,8 +2,6 @@
 
 namespace TreeHouse\BehatCommon;
 
-use Behat\Behat\Hook\Scope\BeforeFeatureScope;
-use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Doctrine\Common\Inflector\Inflector;
@@ -13,25 +11,11 @@ use TreeHouse\BehatCommon\Alice\Instances\Instantiator\Methods\ObjectConstructor
 abstract class AbstractPersistenceContext extends RawMinkContext
 {
     /**
-     * @var bool
+     * @Given /^the database has been purged$/
      */
-    protected $purgedDb = false;
-
-    /**
-     * @AfterScenario
-     */
-    public function afterScenario()
+    public function theDatabaseHasBeenPurged()
     {
-        $this->purgedDb = false;
-    }
-
-    protected function ensurePurgedDb()
-    {
-        if (!$this->purgedDb) {
-            $this->purgeDatabase();
-
-            $this->purgedDb = true;
-        }
+        $this->purgeDatabase();
     }
 
     /**
@@ -41,8 +25,6 @@ abstract class AbstractPersistenceContext extends RawMinkContext
      */
     public function theFollowingDataShouldBePersisted($name, TableNode $data)
     {
-        $this->ensurePurgedDb();
-
         $this->persistData($name, $data->getHash());
     }
 
@@ -53,8 +35,6 @@ abstract class AbstractPersistenceContext extends RawMinkContext
      */
     public function theFollowingDataShouldHaveBeenPersisted($name, TableNode $data)
     {
-        $this->ensurePurgedDb();
-
         $this->assertDataPersisted($name, $data->getHash());
     }
 
@@ -65,8 +45,6 @@ abstract class AbstractPersistenceContext extends RawMinkContext
      */
     public function theFollowingDataShouldNotHaveBeenPersisted($name, TableNode $data)
     {
-        $this->ensurePurgedDb();
-
         $this->assertDataNotPersisted($name, $data->getHash());
     }
 
@@ -102,7 +80,7 @@ abstract class AbstractPersistenceContext extends RawMinkContext
     }
 
     /**
-     * Singularifies a given value
+     * Singularifies a given value.
      *
      * @param string $value
      *
@@ -120,7 +98,7 @@ abstract class AbstractPersistenceContext extends RawMinkContext
     }
 
     /**
-     * Removes a value with the given $key from an array, if it exists
+     * Removes a value with the given $key from an array, if it exists.
      *
      * @param string $key
      * @param array  $data
@@ -134,7 +112,7 @@ abstract class AbstractPersistenceContext extends RawMinkContext
 
     /**
      * Allows subclasses to apply their specific mapping to any data
-     * that is being persisted to, or queried against the database
+     * that is being persisted to, or queried against the database.
      *
      * @param array $mapping
      * @param array $data
@@ -156,7 +134,7 @@ abstract class AbstractPersistenceContext extends RawMinkContext
     }
 
     /**
-     * Allows subclasses to define a base set of fixture data that will be used when persisting data to the database
+     * Allows subclasses to define a base set of fixture data that will be used when persisting data to the database.
      *
      * Note: this is called before applyMapping(), so field names should be connection-agnostic!
      *
@@ -186,7 +164,7 @@ abstract class AbstractPersistenceContext extends RawMinkContext
 
     /**
      * Return any mapping you want to be performed on
-     * data/criteria that will be tested against the database
+     * data/criteria that will be tested against the database.
      *
      * If you return an empty array no mapping will be applied
      * In all other cases every key in the original data
@@ -228,7 +206,7 @@ abstract class AbstractPersistenceContext extends RawMinkContext
 
     /**
      * Purges the relevant database, if the scenario was tagged
-     * with the tag configured during construction
+     * with the tag configured during construction.
      */
     abstract protected function purgeDatabase();
 }

--- a/src/TreeHouse/BehatCommon/FormContext.php
+++ b/src/TreeHouse/BehatCommon/FormContext.php
@@ -36,7 +36,7 @@ class FormContext extends RawMinkContext
     }
 
     /**
-     * @Then the field :name should not/NOT have an error containing :message
+     * @Then the field :name should not have an error containing :message
      */
     public function theFieldShouldNotHaveAnErrorContaining($name, $message)
     {

--- a/src/TreeHouse/BehatCommon/KernelAwareTrait.php
+++ b/src/TreeHouse/BehatCommon/KernelAwareTrait.php
@@ -16,7 +16,7 @@ trait KernelAwareTrait
     private $kernel;
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function setKernel(KernelInterface $kernel)
     {

--- a/src/TreeHouse/BehatCommon/NavigationContext.php
+++ b/src/TreeHouse/BehatCommon/NavigationContext.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace TreeHouse\BehatCommon;
+
+use Behat\MinkExtension\Context\RawMinkContext;
+use PHPUnit_Framework_Assert as Assert;
+
+class NavigationContext extends RawMinkContext
+{
+    /**
+     * @Then the current URL should end with :suffix
+     */
+    public function theCurrentUrlShouldEndWith($suffix)
+    {
+        Assert::assertStringEndsWith($suffix, $this->getSession()->getCurrentUrl());
+    }
+}

--- a/src/TreeHouse/BehatCommon/PDOContext.php
+++ b/src/TreeHouse/BehatCommon/PDOContext.php
@@ -34,25 +34,21 @@ class PDOContext extends AbstractPersistenceContext
     private $connection;
 
     /**
-     * @param string      $dsn
-     * @param string      $username
-     * @param string      $password
-     * @param array       $options
-     * @param string|null $purge_database_tag
+     * @param string $dsn
+     * @param string $username
+     * @param string $password
+     * @param array  $options
      */
-    public function __construct($dsn, $username, $password, array $options = [], $purge_database_tag = 'purgedb')
+    public function __construct($dsn, $username, $password, array $options = [])
     {
         $this->dsn = $dsn;
         $this->username = $username;
         $this->password = $password;
         $this->options = $options;
-
-        parent::__construct($purge_database_tag);
     }
 
     /**
-     * @param string $name
-     * @param array  $data
+     * @inheritdoc
      */
     protected function persistData($name, array $data)
     {
@@ -62,8 +58,7 @@ class PDOContext extends AbstractPersistenceContext
     }
 
     /**
-     * @param string $name
-     * @param array  $data
+     * @inheritdoc
      */
     protected function assertDataPersisted($name, array $data)
     {
@@ -73,9 +68,7 @@ class PDOContext extends AbstractPersistenceContext
     }
 
     /**
-     * @Then /^the following (.*?) should NOT exist:$/
-     *
-     * {@inheritdoc}
+     * @inheritdoc
      */
     protected function assertDataNotPersisted($name, array $data)
     {
@@ -98,7 +91,7 @@ class PDOContext extends AbstractPersistenceContext
             $parameters = [];
 
             foreach ($data as $key => $value) {
-                $parameters[$key] = ':' . $key;
+                $parameters[$key] = ':'.$key;
             }
             $conn->beginTransaction();
             $sql = sprintf(
@@ -153,7 +146,7 @@ class PDOContext extends AbstractPersistenceContext
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     protected function purgeDatabase()
     {
@@ -198,7 +191,7 @@ class PDOContext extends AbstractPersistenceContext
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     protected function persistRows($table, array $rows)
     {
@@ -211,7 +204,7 @@ class PDOContext extends AbstractPersistenceContext
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     protected function assertRowsHaveBeenPersisted($table, $rows)
     {
@@ -225,7 +218,7 @@ class PDOContext extends AbstractPersistenceContext
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     protected function assertRowsHaveNotBeenPersisted($table, $rows)
     {

--- a/src/TreeHouse/BehatCommon/SecurityContext.php
+++ b/src/TreeHouse/BehatCommon/SecurityContext.php
@@ -115,9 +115,9 @@ class SecurityContext extends RawMinkContext implements KernelAwareContext
     }
 
     /**
-     * @Then I should NOT be logged in
-     * @Then I should NOT be logged in as :value
-     * @Then I should NOT be logged in with :key :value
+     * @Then I should not be logged in
+     * @Then I should not be logged in as :value
+     * @Then I should not be logged in with :key :value
      *
      * @param string|null $keyOrValue
      * @param string|null $value

--- a/src/TreeHouse/BehatCommon/SeoContext.php
+++ b/src/TreeHouse/BehatCommon/SeoContext.php
@@ -51,6 +51,26 @@ class SeoContext extends RawMinkContext
     }
 
     /**
+     * @Then there should be a meta-tag with property :propertyValue and content :contentValue
+     */
+    public function thereShouldBeAMetaTagWithPropertyAndContent($propertyValue, $contentValue)
+    {
+        $tag = $this->getMetaTagByProperty($propertyValue);
+
+        Assert::assertSame($contentValue, $tag->getAttribute('content'));
+    }
+
+    /**
+     * @Then there should be a meta-tag with property :propertyValue and content matching :contentValueRegex
+     */
+    public function thereShouldBeAMetaTagWithPropertyAndContentMatching($propertyValue, $contentValueRegex)
+    {
+        $tag = $this->getMetaTagByProperty($propertyValue);
+
+        Assert::assertRegExp($contentValueRegex, $tag->getAttribute('content'));
+    }
+
+    /**
      * @Then there should be a meta-tag with attribute :attributeKey and value :attributeValue
      */
     public function thereShouldBeAMetaTagWithAttributeAndValue($attributeKey, $attributeValue)
@@ -72,6 +92,14 @@ class SeoContext extends RawMinkContext
     public function thereShouldBeALinkTitled($title)
     {
         $this->assertSession()->elementExists('css', sprintf('a:contains("%s")', $title));
+    }
+
+    /**
+     * @Then there should not be a link titled :title
+     */
+    public function thereShouldNotBeALinkTitled($title)
+    {
+        $this->assertSession()->elementNotExists('css', sprintf('a:contains("%s")', $title));
     }
 
     /**
@@ -125,8 +153,28 @@ class SeoContext extends RawMinkContext
                 $needle = substr($action, 0, -2);
                 break;
             default:
-                $needle = $action;
+                throw new \InvalidArgumentException(sprintf('Unknown robots action: %s',$action));
+        }
+
+        Assert::assertContains($needle, $this->getRobotDirectives());
+    }
+
+    /**
+     * @Then the page can not be :action by robots
+     */
+    public function thePageCanNotBeActionByRobots($action)
+    {
+        $action = strtolower($action);
+
+        switch ($action) {
+            case 'indexed':
+                $needle = "noindex";
                 break;
+            case 'followed':
+                $needle = "nofollow";
+                break;
+            default:
+                throw new \InvalidArgumentException(sprintf('Unknown robots action: %s',$action));
         }
 
         Assert::assertContains($needle, $this->getRobotDirectives());
@@ -188,7 +236,17 @@ class SeoContext extends RawMinkContext
      */
     protected function getMetaTag($name)
     {
-        return $this->assertSession()->elementExists('css', sprintf('meta[name=%s]', $name));
+        return $this->assertSession()->elementExists('css', sprintf('meta[name="%s"]', $name));
+    }
+
+    /**
+     * @param string $property
+     *
+     * @return NodeElement
+     */
+    protected function getMetaTagByProperty($property)
+    {
+        return $this->assertSession()->elementExists('css', sprintf('meta[property="%s"]', $property));
     }
 
     /**

--- a/src/TreeHouse/BehatCommon/SwiftmailerContext.php
+++ b/src/TreeHouse/BehatCommon/SwiftmailerContext.php
@@ -187,7 +187,7 @@ class SwiftmailerContext extends RawMinkContext implements KernelAwareContext
      */
     public function theEmailBodyShouldNotHaveAttachment($name)
     {
-        Assert::assertFalse(in_array($name, $this->getEmailAttachments()), sprintf('File with name "%s" should NOT be found in the attachment(s)', $name));
+        Assert::assertFalse(in_array($name, $this->getEmailAttachments()), sprintf('File with name "%s" should not be found in the attachment(s)', $name));
     }
 
     /**


### PR DESCRIPTION
Some miscellaneous improvements;
- Replaced `NOT`s with `not`s (casing became annoying to maintain)
- Made it possible to use embedded field names in fixtures again (e.g. `profile.first_name`)
- Replaced requirement of `@purgedb` tag: you must explicitly use the (new) step `the database has been purged`.
- Added step to check ending of current URL (including any GET parameters, which are ignored by the `I should be on ...` step)
- Added step for checking meta-tags by their `property` and `content` attributes (useful for opengraph tags like `og:title`)
