### PR TITLE
Added step for following current redirects (i.e. while sending mail)

### DIFF
--- a/src/TreeHouse/BehatCommon/RedirectContext.php
+++ b/src/TreeHouse/BehatCommon/RedirectContext.php
@@ -7,6 +7,7 @@ use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\MinkExtension\Context\RawMinkContext;
 use PHPUnit_Framework_Assert as Assert;
 use Symfony\Component\BrowserKit\Client;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class RedirectContext extends RawMinkContext
 {
@@ -26,6 +27,18 @@ class RedirectContext extends RawMinkContext
     public function iDoNotFollowRedirects()
     {
         $this->getClient()->followRedirects(false);
+    }
+
+    /**
+     * @When I follow the current redirect
+     */
+    public function iFollowTheCurrentRedirect()
+    {
+        $response = $this->getClient()->getResponse();
+
+        Assert::assertInstanceOf(RedirectResponse::class, $response);
+
+        $this->getSession()->visit($response->getTargetUrl());
     }
 
     /**


### PR DESCRIPTION
Sometimes you might not know the target URL of a redirect, but still want to test that an e-mail is being sent (requires `I do not follow redirects`).

``` gherkin
...
# prevent following next redirect
And I do not follow redirects 
# step that triggers the redirect
And I submit the form "my_form" 
# test e-mail is sent correctly (only possible when not following redirects)
Then an email with subject "This is the e-mail" should have been sent to "foobar@example.com"  
# return to normal behaviour without having to know the target URL
And I follow the current redirect 
...
```
