### PR TITLE
Added returns to fixture assertions

### DIFF
--- a/src/TreeHouse/BehatCommon/AbstractPersistenceContext.php
+++ b/src/TreeHouse/BehatCommon/AbstractPersistenceContext.php
@@ -165,6 +165,8 @@ abstract class AbstractPersistenceContext extends RawMinkContext
      * @param array  $data
      *
      * @throw \PHPUnit_Framework_ExpectationFailedException
+     *
+     * @return mixed[]
      */
     abstract protected function assertDataPersisted($name, array $data);
 

--- a/src/TreeHouse/BehatCommon/DoctrineOrmContext.php
+++ b/src/TreeHouse/BehatCommon/DoctrineOrmContext.php
@@ -71,6 +71,7 @@ class DoctrineOrmContext extends AbstractPersistenceContext implements KernelAwa
     {
         $alias = $this->convertNameToAlias($this->singularize($name));
         $class = $this->getEntityManager()->getClassMetadata($alias)->getName();
+        $found = [];
 
         foreach ($data as $row) {
             $criteria = $this->applyMapping($this->getFieldMapping($class), $row);
@@ -98,7 +99,11 @@ class DoctrineOrmContext extends AbstractPersistenceContext implements KernelAwa
                     Assert::assertSame($value, $accessor->getValue($entity, $field));
                 }
             }
+
+            $found[] = $entity;
         }
+
+        return $found;
     }
 
     /**

--- a/src/TreeHouse/BehatCommon/PDOContext.php
+++ b/src/TreeHouse/BehatCommon/PDOContext.php
@@ -68,13 +68,18 @@ class PDOContext extends AbstractPersistenceContext
     protected function assertDataPersisted($name, array $criterias)
     {
         $table = $this->convertNameToTable($this->singularize($name));
+        $found = [];
 
         foreach ($criterias as $criteria) {
             $criteria = $this->applyMapping($this->getFieldMapping($table), $criteria);
             $this->transformFixture($table, $criteria);
             $match = $this->find($table, $criteria);
             Assert::assertNotEmpty($match);
+
+            $found[] = $match;
         }
+
+        return $found;
     }
 
     /**


### PR DESCRIPTION
In some cases users might want to assert certain values on a persisted object (doctrine) or array (pdo).

For example:

``` php

/**
 * @Then the following user should exist with a :property timestamp between :from and :to:
 */
public function theFollowingUserShouldHaveBeenPersistedWithATimestampBetweenAnd($property, $from, $to, TableNode $data)
{
    $accessor = PropertyAccess::createPropertyAccessor();

    // this is the change: we can now access the persisted objects/arrays
    $found = $this->assertDataPersisted('user', $data->getHash());

    $from = new \DateTime($from);
    $to = new \DateTime($to);

    foreach ($found as $user) {
        // for example, we can check if a datetime was set properly
        $timestamp = $accessor->getValue($user, $property);

        \PHPUnit_Framework_Assert::assertInstanceOf(\DateTime::class, $timestamp);
        \PHPUnit_Framework_Assert::assertGreaterThan($from, $timestamp);
        \PHPUnit_Framework_Assert::assertLessThan($to, $timestamp);
    }
}
```
