### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ default:
               - TreeHouse\BehatCommon\SwiftmailerContext
               # Since you are using symfony you probably also need to persist some data with doctrine...?
               - TreeHouse\BehatCommon\DoctrineOrmContext:
-                  prefix: AcmeBundle # defaults to 'AppBundle'
-                  purge_database_tag: purge_db # use this tag in your features to reset the database where needed (default is null)
+                  default_prefix: AcmeBundle # defaults to 'AppBundle'
     extensions:
       Behat\Symfony2Extension: ~
       Behat\MinkExtension:


### PR DESCRIPTION
The `prefix` variable has been renamed to [default_prefix](https://github.com/treehouselabs/behat-common/blob/master/src/TreeHouse/BehatCommon/DoctrineOrmContext.php#L33).  The `purge_database_tag` variable has been dropped altogether.

The documentation did not reflect this yet.
