### PR TITLE
Fixed json refresh issue

### DIFF
--- a/src/TreeHouse/BehatCommon/DoctrineOrmContext.php
+++ b/src/TreeHouse/BehatCommon/DoctrineOrmContext.php
@@ -92,6 +92,9 @@ class DoctrineOrmContext extends AbstractPersistenceContext implements KernelAwa
             );
 
             if (!empty($jsonArrayFields)) {
+                // refresh json fields as they may have changed beforehand
+                $this->getEntityManager()->refresh($entity);
+
                 // json array fields can not be matched by the ORM (depends on driver and requires driver-specific operators),
                 // therefore we need to check these separately
                 $accessor = PropertyAccess::createPropertyAccessor();


### PR DESCRIPTION
Makes sure JSON data is up to date before verifying. This was causing an issue when a JSON field had data in the database but not (yet) in the entity.
