### PR TITLE
Update to swiftmailer 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "doctrine/common": "^2.2",
     "doctrine/data-fixtures": "^1.1",
     "phpunit/phpunit": "^5.7|^6.0",
-    "swiftmailer/swiftmailer": "^5.0",
+    "swiftmailer/swiftmailer": "^6.0",
     "symfony/dependency-injection": "^3.0",
     "symfony/http-kernel": "^3.0",
     "symfony/property-access": "^3.0",

--- a/src/TreeHouse/BehatCommon/SwiftmailerContext.php
+++ b/src/TreeHouse/BehatCommon/SwiftmailerContext.php
@@ -222,7 +222,6 @@ class SwiftmailerContext extends RawMinkContext implements KernelAwareContext
 
         $files = [];
 
-        /** @var \Swift_Mime_MimeEntity $child */
         foreach ($this->message->getChildren() as $child) {
             if (null !== $disposition = $child->getHeaders()->get('content-disposition')) {
                 /** @var \Swift_Mime_Headers_ParameterizedHeader $disposition */


### PR DESCRIPTION
This is needed in order to be able to update HW to SF3.4. It prevents HW from installing symfony/swiftmailer-bundle which needs to be update due to deprecations and preparation for SF4.0.